### PR TITLE
Make Trace ID Optional

### DIFF
--- a/exporter/internal/otlptext/databuffer.go
+++ b/exporter/internal/otlptext/databuffer.go
@@ -250,7 +250,11 @@ func (b *dataBuffer) logLinks(description string, sl ptrace.SpanLinkSlice) {
 		l := sl.At(i)
 		b.logEntry("SpanLink #%d", i)
 		b.logEntry("     -> Trace ID: %s", l.TraceID())
-		b.logEntry("     -> ID: %s", l.SpanID())
+		sp, ok := l.SpanID()
+		if ok {
+			b.logEntry("     -> ID: %s", sp)
+		}
+
 		b.logEntry("     -> TraceState: %s", l.TraceState().AsRaw())
 		b.logEntry("     -> DroppedAttributesCount: %d", l.DroppedAttributesCount())
 		b.logAttributes("     -> Attributes:", l.Attributes())
@@ -268,7 +272,10 @@ func (b *dataBuffer) logExemplars(description string, se pmetric.ExemplarSlice) 
 		e := se.At(i)
 		b.logEntry("Exemplar #%d", i)
 		b.logEntry("     -> Trace ID: %s", e.TraceID())
-		b.logEntry("     -> Span ID: %s", e.SpanID())
+		sp, ok := e.SpanID()
+		if ok {
+			b.logEntry("     -> Span ID: %s", sp)
+		}
 		b.logEntry("     -> Timestamp: %s", e.Timestamp())
 		switch e.ValueType() {
 		case pmetric.ExemplarValueTypeInt:

--- a/exporter/internal/otlptext/databuffer.go
+++ b/exporter/internal/otlptext/databuffer.go
@@ -249,7 +249,10 @@ func (b *dataBuffer) logLinks(description string, sl ptrace.SpanLinkSlice) {
 	for i := 0; i < sl.Len(); i++ {
 		l := sl.At(i)
 		b.logEntry("SpanLink #%d", i)
-		b.logEntry("     -> Trace ID: %s", l.TraceID())
+		tid, ok := l.TraceID()
+		if ok {
+			b.logEntry("     -> Trace ID: %s", tid)
+		}
 		sp, ok := l.SpanID()
 		if ok {
 			b.logEntry("     -> ID: %s", sp)
@@ -271,7 +274,10 @@ func (b *dataBuffer) logExemplars(description string, se pmetric.ExemplarSlice) 
 	for i := 0; i < se.Len(); i++ {
 		e := se.At(i)
 		b.logEntry("Exemplar #%d", i)
-		b.logEntry("     -> Trace ID: %s", e.TraceID())
+		tid, ok := e.TraceID()
+		if ok {
+			b.logEntry("     -> Trace ID: %s", tid)
+		}
 		sp, ok := e.SpanID()
 		if ok {
 			b.logEntry("     -> Span ID: %s", sp)

--- a/exporter/internal/otlptext/logs.go
+++ b/exporter/internal/otlptext/logs.go
@@ -41,7 +41,10 @@ func (textLogsMarshaler) MarshalLogs(ld plog.Logs) ([]byte, error) {
 				buf.logEntry("Body: %s", valueToString(lr.Body()))
 				buf.logAttributes("Attributes", lr.Attributes())
 				buf.logEntry("Trace ID: %s", lr.TraceID())
-				buf.logEntry("Span ID: %s", lr.SpanID())
+				sp, ok := lr.SpanID()
+				if ok {
+					buf.logEntry("Span ID: %s", sp)
+				}
 				buf.logEntry("Flags: %d", lr.Flags())
 			}
 		}

--- a/exporter/internal/otlptext/logs.go
+++ b/exporter/internal/otlptext/logs.go
@@ -40,7 +40,10 @@ func (textLogsMarshaler) MarshalLogs(ld plog.Logs) ([]byte, error) {
 				buf.logEntry("SeverityNumber: %s(%d)", lr.SeverityNumber(), lr.SeverityNumber())
 				buf.logEntry("Body: %s", valueToString(lr.Body()))
 				buf.logAttributes("Attributes", lr.Attributes())
-				buf.logEntry("Trace ID: %s", lr.TraceID())
+				tid, ok := lr.TraceID()
+				if ok {
+					buf.logEntry("Trace ID: %s", tid)
+				}
 				sp, ok := lr.SpanID()
 				if ok {
 					buf.logEntry("Span ID: %s", sp)

--- a/exporter/internal/otlptext/traces.go
+++ b/exporter/internal/otlptext/traces.go
@@ -35,8 +35,14 @@ func (textTracesMarshaler) MarshalTraces(td ptrace.Traces) ([]byte, error) {
 				buf.logEntry("Span #%d", k)
 				span := spans.At(k)
 				buf.logAttr("Trace ID", span.TraceID())
-				buf.logAttr("Parent ID", span.ParentSpanID())
-				buf.logAttr("ID", span.SpanID())
+				psp, ok := span.ParentSpanID()
+				if ok {
+					buf.logAttr("Parent ID", psp)
+				}
+				sp, ok := span.SpanID()
+				if ok {
+					buf.logAttr("ID", sp)
+				}
 				buf.logAttr("Name", span.Name())
 				buf.logAttr("Kind", span.Kind().String())
 				buf.logAttr("Start time", span.StartTimestamp().String())

--- a/exporter/internal/otlptext/traces.go
+++ b/exporter/internal/otlptext/traces.go
@@ -34,7 +34,10 @@ func (textTracesMarshaler) MarshalTraces(td ptrace.Traces) ([]byte, error) {
 			for k := 0; k < spans.Len(); k++ {
 				buf.logEntry("Span #%d", k)
 				span := spans.At(k)
-				buf.logAttr("Trace ID", span.TraceID())
+				tid, ok := span.TraceID()
+				if ok {
+					buf.logAttr("Trace ID", tid)
+				}
 				psp, ok := span.ParentSpanID()
 				if ok {
 					buf.logAttr("Parent ID", psp)

--- a/internal/e2e/otlphttp_test.go
+++ b/internal/e2e/otlphttp_test.go
@@ -247,7 +247,7 @@ func TestIssue_4221(t *testing.T) {
 		span := tr.Traces().ResourceSpans().At(0).ScopeSpans().At(0).Spans().At(0)
 		traceID := span.TraceID()
 		assert.Equal(t, "4303853f086f4f8c86cf198b6551df84", hex.EncodeToString(traceID[:]))
-		spanID := span.SpanID()
+		spanID, _ := span.SpanID()
 		assert.Equal(t, "e5513c32795c41b9", hex.EncodeToString(spanID[:]))
 	}))
 	defer func() { svr.Close() }()
@@ -276,7 +276,7 @@ func TestIssue_4221(t *testing.T) {
 	require.NoError(t, err)
 	copy(spanIDBytes[:], spanIDBytesSlice)
 	span.SetSpanID(spanIDBytes)
-	spanID := span.SpanID()
+	spanID, _ := span.SpanID()
 	assert.Equal(t, "e5513c32795c41b9", hex.EncodeToString(spanID[:]))
 
 	span.SetEndTimestamp(1634684637873000000)

--- a/internal/e2e/otlphttp_test.go
+++ b/internal/e2e/otlphttp_test.go
@@ -245,7 +245,7 @@ func TestIssue_4221(t *testing.T) {
 		tr := ptraceotlp.NewExportRequest()
 		require.NoError(t, tr.UnmarshalProto(unbase64Data))
 		span := tr.Traces().ResourceSpans().At(0).ScopeSpans().At(0).Spans().At(0)
-		traceID := span.TraceID()
+		traceID, _ := span.TraceID()
 		assert.Equal(t, "4303853f086f4f8c86cf198b6551df84", hex.EncodeToString(traceID[:]))
 		spanID, _ := span.SpanID()
 		assert.Equal(t, "e5513c32795c41b9", hex.EncodeToString(spanID[:]))
@@ -268,7 +268,7 @@ func TestIssue_4221(t *testing.T) {
 	require.NoError(t, err)
 	copy(traceIDBytes[:], traceIDBytesSlice)
 	span.SetTraceID(traceIDBytes)
-	traceID := span.TraceID()
+	traceID, _ := span.TraceID()
 	assert.Equal(t, "4303853f086f4f8c86cf198b6551df84", hex.EncodeToString(traceID[:]))
 
 	var spanIDBytes [8]byte

--- a/pdata/plog/generated_logrecord.go
+++ b/pdata/plog/generated_logrecord.go
@@ -85,8 +85,13 @@ func (ms LogRecord) SetTraceID(v pcommon.TraceID) {
 }
 
 // SpanID returns the spanid associated with this LogRecord.
-func (ms LogRecord) SpanID() pcommon.SpanID {
-	return pcommon.SpanID(ms.orig.SpanId)
+// Returns the span ID and whether it exists.
+func (ms LogRecord) SpanID() (pcommon.SpanID, bool) {
+	if len(ms.orig.SpanId) != 8 {
+		return pcommon.NewSpanIDEmpty(), false
+	}
+
+	return pcommon.SpanID(ms.orig.SpanId), true
 }
 
 // SetSpanID replaces the spanid associated with this LogRecord.
@@ -155,7 +160,10 @@ func (ms LogRecord) CopyTo(dest LogRecord) {
 	dest.SetObservedTimestamp(ms.ObservedTimestamp())
 	dest.SetTimestamp(ms.Timestamp())
 	dest.SetTraceID(ms.TraceID())
-	dest.SetSpanID(ms.SpanID())
+	sp, ok := ms.SpanID()
+	if ok {
+		dest.SetSpanID(sp)
+	}
 	dest.SetFlags(ms.Flags())
 	dest.SetSeverityText(ms.SeverityText())
 	dest.SetSeverityNumber(ms.SeverityNumber())

--- a/pdata/plog/generated_logrecord.go
+++ b/pdata/plog/generated_logrecord.go
@@ -74,8 +74,12 @@ func (ms LogRecord) SetTimestamp(v pcommon.Timestamp) {
 }
 
 // TraceID returns the traceid associated with this LogRecord.
-func (ms LogRecord) TraceID() pcommon.TraceID {
-	return pcommon.TraceID(ms.orig.TraceId)
+func (ms LogRecord) TraceID() (pcommon.TraceID, bool) {
+	if len(ms.orig.TraceId) != 16 {
+		return pcommon.NewTraceIDEmpty(), false
+	}
+
+	return pcommon.TraceID(ms.orig.TraceId), true
 }
 
 // SetTraceID replaces the traceid associated with this LogRecord.
@@ -159,7 +163,10 @@ func (ms LogRecord) CopyTo(dest LogRecord) {
 	dest.state.AssertMutable()
 	dest.SetObservedTimestamp(ms.ObservedTimestamp())
 	dest.SetTimestamp(ms.Timestamp())
-	dest.SetTraceID(ms.TraceID())
+	tid, ok := ms.TraceID()
+	if ok {
+		dest.SetTraceID(tid)
+	}
 	sp, ok := ms.SpanID()
 	if ok {
 		dest.SetSpanID(sp)

--- a/pdata/plog/generated_logrecord_test.go
+++ b/pdata/plog/generated_logrecord_test.go
@@ -58,10 +58,12 @@ func TestLogRecord_Timestamp(t *testing.T) {
 
 func TestLogRecord_TraceID(t *testing.T) {
 	ms := NewLogRecord()
-	assert.Equal(t, pcommon.TraceID(data.TraceID([16]byte{})), ms.TraceID())
+	tid, _ := ms.TraceID()
+	assert.Equal(t, pcommon.TraceID(data.TraceID([16]byte{})), tid)
 	testValTraceID := pcommon.TraceID(data.TraceID([16]byte{1, 2, 3, 4, 5, 6, 7, 8, 8, 7, 6, 5, 4, 3, 2, 1}))
 	ms.SetTraceID(testValTraceID)
-	assert.Equal(t, testValTraceID, ms.TraceID())
+	tid, _ = ms.TraceID()
+	assert.Equal(t, testValTraceID, tid)
 }
 
 func TestLogRecord_SpanID(t *testing.T) {

--- a/pdata/plog/generated_logrecord_test.go
+++ b/pdata/plog/generated_logrecord_test.go
@@ -66,10 +66,12 @@ func TestLogRecord_TraceID(t *testing.T) {
 
 func TestLogRecord_SpanID(t *testing.T) {
 	ms := NewLogRecord()
-	assert.Equal(t, pcommon.SpanID(data.SpanID([8]byte{})), ms.SpanID())
+	sp, _ :=  ms.SpanID()
+	assert.Equal(t, pcommon.SpanID(data.SpanID([8]byte{})), sp)
 	testValSpanID := pcommon.SpanID(data.SpanID([8]byte{8, 7, 6, 5, 4, 3, 2, 1}))
 	ms.SetSpanID(testValSpanID)
-	assert.Equal(t, testValSpanID, ms.SpanID())
+	sp, _ = ms.SpanID()
+	assert.Equal(t, testValSpanID, sp)
 }
 
 func TestLogRecord_Flags(t *testing.T) {

--- a/pdata/pmetric/generated_exemplar.go
+++ b/pdata/pmetric/generated_exemplar.go
@@ -109,8 +109,12 @@ func (ms Exemplar) FilteredAttributes() pcommon.Map {
 }
 
 // TraceID returns the traceid associated with this Exemplar.
-func (ms Exemplar) TraceID() pcommon.TraceID {
-	return pcommon.TraceID(ms.orig.TraceId)
+func (ms Exemplar) TraceID() (pcommon.TraceID, bool) {
+	if len(ms.orig.TraceId) != 16 {
+		return pcommon.NewTraceIDEmpty(), false
+	}
+
+	return pcommon.TraceID(ms.orig.TraceId), true
 }
 
 // SetTraceID replaces the traceid associated with this Exemplar.
@@ -147,7 +151,10 @@ func (ms Exemplar) CopyTo(dest Exemplar) {
 	}
 
 	ms.FilteredAttributes().CopyTo(dest.FilteredAttributes())
-	dest.SetTraceID(ms.TraceID())
+	tid, ok := ms.TraceID()
+	if ok {
+		dest.SetTraceID(tid)
+	}
 	sp, ok := ms.SpanID()
 	if ok {
 		dest.SetSpanID(sp)

--- a/pdata/pmetric/generated_exemplar.go
+++ b/pdata/pmetric/generated_exemplar.go
@@ -120,8 +120,13 @@ func (ms Exemplar) SetTraceID(v pcommon.TraceID) {
 }
 
 // SpanID returns the spanid associated with this Exemplar.
-func (ms Exemplar) SpanID() pcommon.SpanID {
-	return pcommon.SpanID(ms.orig.SpanId)
+// Returns the span ID and whether it exists.
+func (ms Exemplar) SpanID() (pcommon.SpanID, bool) {
+	if len(ms.orig.SpanId) != 8 {
+		return pcommon.NewSpanIDEmpty(), false
+	}
+
+	return pcommon.SpanID(ms.orig.SpanId), true
 }
 
 // SetSpanID replaces the spanid associated with this Exemplar.
@@ -143,5 +148,8 @@ func (ms Exemplar) CopyTo(dest Exemplar) {
 
 	ms.FilteredAttributes().CopyTo(dest.FilteredAttributes())
 	dest.SetTraceID(ms.TraceID())
-	dest.SetSpanID(ms.SpanID())
+	sp, ok := ms.SpanID()
+	if ok {
+		dest.SetSpanID(sp)
+	}
 }

--- a/pdata/pmetric/generated_exemplar_test.go
+++ b/pdata/pmetric/generated_exemplar_test.go
@@ -90,10 +90,12 @@ func TestExemplar_TraceID(t *testing.T) {
 
 func TestExemplar_SpanID(t *testing.T) {
 	ms := NewExemplar()
-	assert.Equal(t, pcommon.SpanID(data.SpanID([8]byte{})), ms.SpanID())
+	sp, _ := ms.SpanID()
+	assert.Equal(t, pcommon.SpanID(data.SpanID([8]byte{})), sp)
 	testValSpanID := pcommon.SpanID(data.SpanID([8]byte{8, 7, 6, 5, 4, 3, 2, 1}))
 	ms.SetSpanID(testValSpanID)
-	assert.Equal(t, testValSpanID, ms.SpanID())
+	sp, _ = ms.SpanID()
+	assert.Equal(t, testValSpanID, sp)
 }
 
 func generateTestExemplar() Exemplar {

--- a/pdata/pmetric/generated_exemplar_test.go
+++ b/pdata/pmetric/generated_exemplar_test.go
@@ -82,10 +82,12 @@ func TestExemplar_FilteredAttributes(t *testing.T) {
 
 func TestExemplar_TraceID(t *testing.T) {
 	ms := NewExemplar()
-	assert.Equal(t, pcommon.TraceID(data.TraceID([16]byte{})), ms.TraceID())
+	tid, _ := ms.TraceID()
+	assert.Equal(t, pcommon.TraceID(data.TraceID([16]byte{})), tid)
 	testValTraceID := pcommon.TraceID(data.TraceID([16]byte{1, 2, 3, 4, 5, 6, 7, 8, 8, 7, 6, 5, 4, 3, 2, 1}))
 	ms.SetTraceID(testValTraceID)
-	assert.Equal(t, testValTraceID, ms.TraceID())
+	tid, _ = ms.TraceID()
+	assert.Equal(t, testValTraceID, tid)
 }
 
 func TestExemplar_SpanID(t *testing.T) {
@@ -108,6 +110,6 @@ func fillTestExemplar(tv Exemplar) {
 	tv.orig.TimeUnixNano = 1234567890
 	tv.orig.Value = &otlpmetrics.Exemplar_AsInt{AsInt: int64(17)}
 	internal.FillTestMap(internal.NewMap(&tv.orig.FilteredAttributes, tv.state))
-	tv.orig.TraceId = data.TraceID([16]byte{1, 2, 3, 4, 5, 6, 7, 8, 8, 7, 6, 5, 4, 3, 2, 1})
-	tv.orig.SpanId = data.SpanID([8]byte{8, 7, 6, 5, 4, 3, 2, 1})
+	tv.orig.TraceId = []byte{1, 2, 3, 4, 5, 6, 7, 8, 8, 7, 6, 5, 4, 3, 2, 1}
+	tv.orig.SpanId = []byte{8, 7, 6, 5, 4, 3, 2, 1}
 }

--- a/pdata/ptrace/generated_span.go
+++ b/pdata/ptrace/generated_span.go
@@ -64,8 +64,13 @@ func (ms Span) SetTraceID(v pcommon.TraceID) {
 }
 
 // SpanID returns the spanid associated with this Span.
-func (ms Span) SpanID() pcommon.SpanID {
-	return pcommon.SpanID(ms.orig.SpanId)
+// Returns the span id and whether it exists.
+func (ms Span) SpanID() (pcommon.SpanID, bool) {
+	if len(ms.orig.SpanId) != 8 {
+		return pcommon.NewSpanIDEmpty(), false
+	}
+
+	return pcommon.SpanID(ms.orig.SpanId), true
 }
 
 // SetSpanID replaces the spanid associated with this Span.
@@ -80,8 +85,13 @@ func (ms Span) TraceState() pcommon.TraceState {
 }
 
 // ParentSpanID returns the parentspanid associated with this Span.
-func (ms Span) ParentSpanID() pcommon.SpanID {
-	return pcommon.SpanID(ms.orig.ParentSpanId)
+// Returns the span id and whether it exists.
+func (ms Span) ParentSpanID() (pcommon.SpanID, bool) {
+	if len(ms.orig.ParentSpanId) != 8 {
+		return pcommon.NewSpanIDEmpty(), false
+	}
+
+	return pcommon.SpanID(ms.orig.ParentSpanId), true
 }
 
 // SetParentSpanID replaces the parentspanid associated with this Span.
@@ -202,9 +212,15 @@ func (ms Span) Status() Status {
 func (ms Span) CopyTo(dest Span) {
 	dest.state.AssertMutable()
 	dest.SetTraceID(ms.TraceID())
-	dest.SetSpanID(ms.SpanID())
+	sp, ok := ms.SpanID()
+	if ok {
+		dest.SetSpanID(sp)
+	}
 	ms.TraceState().CopyTo(dest.TraceState())
-	dest.SetParentSpanID(ms.ParentSpanID())
+	psp, ok := ms.ParentSpanID()
+	if ok {
+		dest.SetParentSpanID(psp)
+	}
 	dest.SetName(ms.Name())
 	dest.SetFlags(ms.Flags())
 	dest.SetKind(ms.Kind())

--- a/pdata/ptrace/generated_span.go
+++ b/pdata/ptrace/generated_span.go
@@ -53,8 +53,12 @@ func (ms Span) IsNil() bool {
 }
 
 // TraceID returns the traceid associated with this Span.
-func (ms Span) TraceID() pcommon.TraceID {
-	return pcommon.TraceID(ms.orig.TraceId)
+func (ms Span) TraceID() (pcommon.TraceID, bool) {
+	if len(ms.orig.TraceId) != 16 {
+		return pcommon.NewTraceIDEmpty(), false
+	}
+
+	return pcommon.TraceID(ms.orig.TraceId), true
 }
 
 // SetTraceID replaces the traceid associated with this Span.
@@ -211,7 +215,10 @@ func (ms Span) Status() Status {
 // CopyTo copies all properties from the current struct overriding the destination.
 func (ms Span) CopyTo(dest Span) {
 	dest.state.AssertMutable()
-	dest.SetTraceID(ms.TraceID())
+	tid, ok := ms.TraceID()
+	if ok {
+		dest.SetTraceID(tid)
+	}
 	sp, ok := ms.SpanID()
 	if ok {
 		dest.SetSpanID(sp)

--- a/pdata/ptrace/generated_span_test.go
+++ b/pdata/ptrace/generated_span_test.go
@@ -50,10 +50,12 @@ func TestSpan_TraceID(t *testing.T) {
 
 func TestSpan_SpanID(t *testing.T) {
 	ms := NewSpan()
-	assert.Equal(t, pcommon.SpanID(data.SpanID([8]byte{})), ms.SpanID())
+	sp, _ := ms.SpanID()
+	assert.Equal(t, pcommon.SpanID(data.SpanID([8]byte{})), sp)
 	testValSpanID := pcommon.SpanID(data.SpanID([8]byte{8, 7, 6, 5, 4, 3, 2, 1}))
 	ms.SetSpanID(testValSpanID)
-	assert.Equal(t, testValSpanID, ms.SpanID())
+	sp, _ = ms.SpanID()
+	assert.Equal(t, testValSpanID, sp)
 }
 
 func TestSpan_TraceState(t *testing.T) {
@@ -64,10 +66,12 @@ func TestSpan_TraceState(t *testing.T) {
 
 func TestSpan_ParentSpanID(t *testing.T) {
 	ms := NewSpan()
-	assert.Equal(t, pcommon.SpanID(data.SpanID([8]byte{})), ms.ParentSpanID())
+	sp, _ := ms.ParentSpanID()
+	assert.Equal(t, pcommon.SpanID(data.SpanID([8]byte{})), sp)
 	testValParentSpanID := pcommon.SpanID(data.SpanID([8]byte{8, 7, 6, 5, 4, 3, 2, 1}))
 	ms.SetParentSpanID(testValParentSpanID)
-	assert.Equal(t, testValParentSpanID, ms.ParentSpanID())
+	sp, _ = ms.ParentSpanID()
+	assert.Equal(t, testValParentSpanID, sp)
 }
 
 func TestSpan_Name(t *testing.T) {

--- a/pdata/ptrace/generated_span_test.go
+++ b/pdata/ptrace/generated_span_test.go
@@ -42,10 +42,12 @@ func TestSpan_CopyTo(t *testing.T) {
 
 func TestSpan_TraceID(t *testing.T) {
 	ms := NewSpan()
-	assert.Equal(t, pcommon.TraceID(data.TraceID([16]byte{})), ms.TraceID())
+	tid, _ := ms.TraceID()
+	assert.Equal(t, pcommon.TraceID(data.TraceID([16]byte{})), tid)
 	testValTraceID := pcommon.TraceID(data.TraceID([16]byte{1, 2, 3, 4, 5, 6, 7, 8, 8, 7, 6, 5, 4, 3, 2, 1}))
 	ms.SetTraceID(testValTraceID)
-	assert.Equal(t, testValTraceID, ms.TraceID())
+	tid, _ = ms.TraceID()
+	assert.Equal(t, testValTraceID, tid)
 }
 
 func TestSpan_SpanID(t *testing.T) {

--- a/pdata/ptrace/generated_spanlink.go
+++ b/pdata/ptrace/generated_spanlink.go
@@ -54,8 +54,12 @@ func (ms SpanLink) IsNil() bool {
 }
 
 // TraceID returns the traceid associated with this SpanLink.
-func (ms SpanLink) TraceID() pcommon.TraceID {
-	return pcommon.TraceID(ms.orig.TraceId)
+func (ms SpanLink) TraceID() (pcommon.TraceID, bool) {
+	if len(ms.orig.TraceId) != 16 {
+		return pcommon.TraceID{}, false
+	}
+
+	return pcommon.TraceID(ms.orig.TraceId), true
 }
 
 // SetTraceID replaces the traceid associated with this SpanLink.
@@ -113,7 +117,10 @@ func (ms SpanLink) SetDroppedAttributesCount(v uint32) {
 // CopyTo copies all properties from the current struct overriding the destination.
 func (ms SpanLink) CopyTo(dest SpanLink) {
 	dest.state.AssertMutable()
-	dest.SetTraceID(ms.TraceID())
+	tid, ok := ms.TraceID()
+	if ok {
+		dest.SetTraceID(tid)
+	}
 	sp, ok := ms.SpanID()
 	if ok {
 		dest.SetSpanID(sp)

--- a/pdata/ptrace/generated_spanlink.go
+++ b/pdata/ptrace/generated_spanlink.go
@@ -65,8 +65,11 @@ func (ms SpanLink) SetTraceID(v pcommon.TraceID) {
 }
 
 // SpanID returns the spanid associated with this SpanLink.
-func (ms SpanLink) SpanID() pcommon.SpanID {
-	return pcommon.SpanID(ms.orig.SpanId)
+func (ms SpanLink) SpanID() (pcommon.SpanID, bool) {
+	if len(ms.orig.SpanId) != 8 {
+		return pcommon.SpanID{}, false
+	}
+	return pcommon.SpanID(ms.orig.SpanId), true
 }
 
 // SetSpanID replaces the spanid associated with this SpanLink.
@@ -111,7 +114,10 @@ func (ms SpanLink) SetDroppedAttributesCount(v uint32) {
 func (ms SpanLink) CopyTo(dest SpanLink) {
 	dest.state.AssertMutable()
 	dest.SetTraceID(ms.TraceID())
-	dest.SetSpanID(ms.SpanID())
+	sp, ok := ms.SpanID()
+	if ok {
+		dest.SetSpanID(sp)
+	}
 	ms.TraceState().CopyTo(dest.TraceState())
 	dest.SetFlags(ms.Flags())
 	ms.Attributes().CopyTo(dest.Attributes())

--- a/pdata/ptrace/generated_spanlink_test.go
+++ b/pdata/ptrace/generated_spanlink_test.go
@@ -42,10 +42,11 @@ func TestSpanLink_CopyTo(t *testing.T) {
 
 func TestSpanLink_TraceID(t *testing.T) {
 	ms := NewSpanLink()
-	assert.Equal(t, pcommon.TraceID(data.TraceID([16]byte{})), ms.TraceID())
+	tid, _ := ms.TraceID()
+	assert.Equal(t, pcommon.TraceID(data.TraceID([16]byte{})), tid)
 	testValTraceID := pcommon.TraceID(data.TraceID([16]byte{1, 2, 3, 4, 5, 6, 7, 8, 8, 7, 6, 5, 4, 3, 2, 1}))
 	ms.SetTraceID(testValTraceID)
-	assert.Equal(t, testValTraceID, ms.TraceID())
+	assert.Equal(t, testValTraceID, tid)
 }
 
 func TestSpanLink_SpanID(t *testing.T) {

--- a/pdata/ptrace/generated_spanlink_test.go
+++ b/pdata/ptrace/generated_spanlink_test.go
@@ -50,10 +50,12 @@ func TestSpanLink_TraceID(t *testing.T) {
 
 func TestSpanLink_SpanID(t *testing.T) {
 	ms := NewSpanLink()
-	assert.Equal(t, pcommon.SpanID(data.SpanID([8]byte{})), ms.SpanID())
+	sp, _ := ms.SpanID()
+	assert.Equal(t, pcommon.SpanID(data.SpanID([8]byte{})), sp)
 	testValSpanID := pcommon.SpanID(data.SpanID([8]byte{8, 7, 6, 5, 4, 3, 2, 1}))
 	ms.SetSpanID(testValSpanID)
-	assert.Equal(t, testValSpanID, ms.SpanID())
+	sp, _ = ms.SpanID()
+	assert.Equal(t, testValSpanID, sp)
 }
 
 func TestSpanLink_TraceState(t *testing.T) {

--- a/pdata/ptrace/traces_test.go
+++ b/pdata/ptrace/traces_test.go
@@ -160,7 +160,8 @@ func BenchmarkTracesUsage(b *testing.B) {
 					s.SetTraceID([16]byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16})
 					assert.Equal(b, pcommon.TraceID([16]byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16}), s.TraceID())
 					s.SetSpanID([8]byte{1, 2, 3, 4, 5, 6, 7, 8})
-					assert.Equal(b, pcommon.SpanID([8]byte{1, 2, 3, 4, 5, 6, 7, 8}), s.SpanID())
+					sp, _ := s.SpanID()
+					assert.Equal(b, pcommon.SpanID([8]byte{1, 2, 3, 4, 5, 6, 7, 8}), sp)
 				}
 				s := iss.Spans().AppendEmpty()
 				s.SetName("another_span")


### PR DESCRIPTION
With VTProto slice members can be nil.

Typecasting slice to a nil is ok, but TraceID types
are arrays. Arrays cannot be type casted to nil

Change API to return whether the value exists and
return an EmptyTraceID if the value does not exist.