### PR TITLE
Fix broken pcommon due to vtproto

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,8 @@
 module github.com/oodle-ai/opentelemetry-collector
 
-go 1.21.0
+go 1.23
+
+toolchain go1.23.4
 
 require (
 	github.com/oodle-ai/opentelemetry-collector/component v0.0.0-00010101000000-000000000000

--- a/pdata/go.mod
+++ b/pdata/go.mod
@@ -1,6 +1,6 @@
 module github.com/oodle-ai/opentelemetry-collector/pdata
 
-go 1.21.0
+go 1.22
 
 require (
 	github.com/gogo/protobuf v1.3.2

--- a/pdata/go.mod
+++ b/pdata/go.mod
@@ -1,13 +1,12 @@
 module github.com/oodle-ai/opentelemetry-collector/pdata
 
-go 1.22
+go 1.23
 
 require (
 	github.com/gogo/protobuf v1.3.2
 	github.com/json-iterator/go v1.1.12
 	github.com/planetscale/vtprotobuf v0.6.0
 	github.com/stretchr/testify v1.9.0
-	go.opentelemetry.io/proto/otlp v1.2.0
 	go.uber.org/goleak v1.3.0
 	go.uber.org/multierr v1.11.0
 	google.golang.org/grpc v1.64.0

--- a/pdata/go.sum
+++ b/pdata/go.sum
@@ -37,8 +37,6 @@ github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsT
 github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
-go.opentelemetry.io/proto/otlp v1.2.0 h1:pVeZGk7nXDC9O2hncA6nHldxEjm6LByfA2aN8IOkz94=
-go.opentelemetry.io/proto/otlp v1.2.0/go.mod h1:gGpR8txAl5M03pDhMC79G6SdqNV26naRm/KDsgaHD8A=
 go.uber.org/goleak v1.3.0 h1:2K3zAYmnTNqV73imy9J1T3WC+gmCePx2hEGkimedGto=
 go.uber.org/goleak v1.3.0/go.mod h1:CoHD4mav9JJNrW/WLlf7HGZPjdw8EucARQHekz1X6bE=
 go.uber.org/multierr v1.11.0 h1:blXXJkSxSSfBVBlC76pxqeO+LN3aDfLQo+309xJstO0=

--- a/pdata/internal/wrapper_slice.go
+++ b/pdata/internal/wrapper_slice.go
@@ -36,6 +36,7 @@ func FillTestSlice(tv Slice) {
 	*tv.orig = make([]*otlpcommon.AnyValue, 7)
 	for i := 0; i < 7; i++ {
 		state := StateMutable
+		(*tv.orig)[i] = &otlpcommon.AnyValue{}
 		FillTestValue(NewValue((*tv.orig)[i], &state))
 	}
 }

--- a/pdata/pcommon/map.go
+++ b/pdata/pcommon/map.go
@@ -113,7 +113,7 @@ func (m Map) PutEmpty(k string) Value {
 		av.getOrig().Value = nil
 		return newValue(av.getOrig(), m.getState())
 	}
-	*m.getOrig() = append(*m.getOrig(), &otlpcommon.KeyValue{Key: k})
+	*m.getOrig() = append(*m.getOrig(), &otlpcommon.KeyValue{Key: k, Value: &otlpcommon.AnyValue{}})
 	return newValue((*m.getOrig())[len(*m.getOrig())-1].Value, m.getState())
 }
 
@@ -246,6 +246,7 @@ func (m Map) CopyTo(dest Map) {
 	origs := make([]*otlpcommon.KeyValue, len(*m.getOrig()))
 	for i := range *m.getOrig() {
 		akv := (*m.getOrig())[i]
+		origs[i] = &otlpcommon.KeyValue{Key: akv.Key, Value: &otlpcommon.AnyValue{}}
 		origs[i].Key = akv.Key
 		newValue(akv.Value, m.getState()).CopyTo(newValue(origs[i].Value, dest.getState()))
 	}
@@ -274,6 +275,7 @@ func (m Map) FromRaw(rawMap map[string]any) error {
 	origs := make([]*otlpcommon.KeyValue, len(rawMap))
 	ix := 0
 	for k, iv := range rawMap {
+		origs[ix] = &otlpcommon.KeyValue{Value: &otlpcommon.AnyValue{}}
 		origs[ix].Key = k
 		errs = multierr.Append(errs, newValue(origs[ix].Value, m.getState()).FromRaw(iv))
 		ix++

--- a/pdata/pcommon/map_test.go
+++ b/pdata/pcommon/map_test.go
@@ -55,8 +55,8 @@ func TestMap(t *testing.T) {
 
 func TestMapReadOnly(t *testing.T) {
 	state := internal.StateReadOnly
-	m := newMap(&[]otlpcommon.KeyValue{
-		{Key: "k1", Value: otlpcommon.AnyValue{Value: &otlpcommon.AnyValue_StringValue{StringValue: "v1"}}},
+	m := newMap(&[]*otlpcommon.KeyValue{
+		{Key: "k1", Value: &otlpcommon.AnyValue{Value: &otlpcommon.AnyValue_StringValue{StringValue: "v1"}}},
 	}, &state)
 
 	assert.Equal(t, 1, m.Len())
@@ -176,15 +176,15 @@ func TestMapPutEmptyBytes(t *testing.T) {
 }
 
 func TestMapWithEmpty(t *testing.T) {
-	origWithNil := []otlpcommon.KeyValue{
+	origWithNil := []*otlpcommon.KeyValue{
 		{},
 		{
 			Key:   "test_key",
-			Value: otlpcommon.AnyValue{Value: &otlpcommon.AnyValue_StringValue{StringValue: "test_value"}},
+			Value: &otlpcommon.AnyValue{Value: &otlpcommon.AnyValue_StringValue{StringValue: "test_value"}},
 		},
 		{
 			Key:   "test_key2",
-			Value: otlpcommon.AnyValue{Value: nil},
+			Value: &otlpcommon.AnyValue{Value: nil},
 		},
 	}
 	state := internal.StateMutable
@@ -390,7 +390,7 @@ func TestMap_CopyTo(t *testing.T) {
 	assert.EqualValues(t, Map(internal.GenerateTestMap()), dest)
 
 	// Test CopyTo with an empty Value in the destination
-	(*dest.getOrig())[0].Value = otlpcommon.AnyValue{}
+	(*dest.getOrig())[0].Value = &otlpcommon.AnyValue{}
 	Map(internal.GenerateTestMap()).CopyTo(dest)
 	assert.EqualValues(t, Map(internal.GenerateTestMap()), dest)
 }

--- a/pdata/pcommon/slice.go
+++ b/pdata/pcommon/slice.go
@@ -67,6 +67,9 @@ func (es Slice) CopyTo(dest Slice) {
 		(*dest.getOrig()) = (*dest.getOrig())[:srcLen:destCap]
 	} else {
 		(*dest.getOrig()) = make([]*otlpcommon.AnyValue, srcLen)
+		for i := range srcLen {
+			(*dest.getOrig())[i] = &otlpcommon.AnyValue{}
+		}
 	}
 
 	for i := range *es.getOrig() {
@@ -159,6 +162,7 @@ func (es Slice) FromRaw(rawSlice []any) error {
 	var errs error
 	origs := make([]*otlpcommon.AnyValue, len(rawSlice))
 	for ix, iv := range rawSlice {
+		origs[ix] = &otlpcommon.AnyValue{}
 		errs = multierr.Append(errs, newValue(origs[ix], es.getState()).FromRaw(iv))
 	}
 	*es.getOrig() = origs

--- a/pdata/pcommon/slice_test.go
+++ b/pdata/pcommon/slice_test.go
@@ -16,7 +16,7 @@ func TestSlice(t *testing.T) {
 	es := NewSlice()
 	assert.Equal(t, 0, es.Len())
 	state := internal.StateMutable
-	es = newSlice(&[]otlpcommon.AnyValue{}, &state)
+	es = newSlice(&[]*otlpcommon.AnyValue{}, &state)
 	assert.Equal(t, 0, es.Len())
 
 	es.EnsureCapacity(7)
@@ -33,7 +33,7 @@ func TestSlice(t *testing.T) {
 
 func TestSliceReadOnly(t *testing.T) {
 	state := internal.StateReadOnly
-	es := newSlice(&[]otlpcommon.AnyValue{{Value: &otlpcommon.AnyValue_IntValue{IntValue: 3}}}, &state)
+	es := newSlice(&[]*otlpcommon.AnyValue{{Value: &otlpcommon.AnyValue_IntValue{IntValue: 3}}}, &state)
 
 	assert.Equal(t, 1, es.Len())
 	assert.Equal(t, int64(3), es.At(0).Int())

--- a/pdata/pcommon/value.go
+++ b/pdata/pcommon/value.go
@@ -451,7 +451,7 @@ func (v Value) AsRaw() any {
 }
 
 func newKeyValueString(k string, v string) *otlpcommon.KeyValue {
-	orig := otlpcommon.KeyValue{Key: k}
+	orig := otlpcommon.KeyValue{Key: k, Value: &otlpcommon.AnyValue{}}
 	state := internal.StateMutable
 	akv := newValue(orig.Value, &state)
 	akv.SetStr(v)
@@ -459,7 +459,7 @@ func newKeyValueString(k string, v string) *otlpcommon.KeyValue {
 }
 
 func newKeyValueInt(k string, v int64) *otlpcommon.KeyValue {
-	orig := otlpcommon.KeyValue{Key: k}
+	orig := otlpcommon.KeyValue{Key: k, Value: &otlpcommon.AnyValue{}}
 	state := internal.StateMutable
 	akv := newValue(orig.Value, &state)
 	akv.SetInt(v)
@@ -467,7 +467,7 @@ func newKeyValueInt(k string, v int64) *otlpcommon.KeyValue {
 }
 
 func newKeyValueDouble(k string, v float64) *otlpcommon.KeyValue {
-	orig := otlpcommon.KeyValue{Key: k}
+	orig := otlpcommon.KeyValue{Key: k, Value: &otlpcommon.AnyValue{}}
 	state := internal.StateMutable
 	akv := newValue(orig.Value, &state)
 	akv.SetDouble(v)
@@ -475,7 +475,7 @@ func newKeyValueDouble(k string, v float64) *otlpcommon.KeyValue {
 }
 
 func newKeyValueBool(k string, v bool) *otlpcommon.KeyValue {
-	orig := otlpcommon.KeyValue{Key: k}
+	orig := otlpcommon.KeyValue{Key: k, Value: &otlpcommon.AnyValue{}}
 	state := internal.StateMutable
 	akv := newValue(orig.Value, &state)
 	akv.SetBool(v)

--- a/pdata/pcommon/value_test.go
+++ b/pdata/pcommon/value_test.go
@@ -259,7 +259,7 @@ func TestValue_CopyTo(t *testing.T) {
 }
 
 func TestSliceWithNilValues(t *testing.T) {
-	origWithNil := []otlpcommon.AnyValue{
+	origWithNil := []*otlpcommon.AnyValue{
 		{},
 		{Value: &otlpcommon.AnyValue_StringValue{StringValue: "test_value"}},
 	}


### PR DESCRIPTION
Fix tests in pcommon due to changes in proto generated types including pointers instead of values.
